### PR TITLE
support for openshift_postgresql

### DIFF
--- a/src/to_jdbc_uri/core.clj
+++ b/src/to_jdbc_uri/core.clj
@@ -36,6 +36,7 @@
     uri
     (let [parsed-uri (java.net.URI. uri)]
       (case (.getScheme parsed-uri)
-        "postgres" (format-jdbc-uri parsed-uri "postgresql")
+        ;; OPENSHIFT_POSTGRESQL_DB_URL starts with postgresql:// instead of postgres://
+        (or "postgres" "postgresql") (format-jdbc-uri parsed-uri "postgresql")
         "mysql" (format-jdbc-uri parsed-uri "mysql")
         (throw (Exception. (str "Unsupported URI: " uri " please, submit an issue request and we'll try to add it. Pull requests also welcome")))))))

--- a/test/to_jdbc_uri/core_test.clj
+++ b/test/to_jdbc_uri/core_test.clj
@@ -20,6 +20,9 @@
   (testing "Heroku-like PostgreSQL URI with port, username and password"
     (is (= (to-jdbc-uri "postgres://username:password@hostname:1234/dbname")
            "jdbc:postgresql://hostname:1234/dbname?user=username&password=password")))
+  (testing "RedHat OpenShift-like PostgreSQL URI with port, username and password"
+    (is (= (to-jdbc-uri "postgresql://username:password@hostname:1234/dbname")
+           "jdbc:postgresql://hostname:1234/dbname?user=username&password=password")))
   (testing "Heroku-like MySQL URI with port, username and password"
     (is (= (to-jdbc-uri "mysql://username:password@hostname:1234/dbname")
            "jdbc:mysql://hostname:1234/dbname?user=username&password=password")))


### PR DESCRIPTION
OPENSHIFT_POSTGRESQL_DB_URL starts with postgresql:// instead of postgres://
